### PR TITLE
Position delveTip and worldTip above charTip when no space below

### DIFF
--- a/DataBroker.lua
+++ b/DataBroker.lua
@@ -118,6 +118,13 @@ local function OpenAllTips(display, mode)
     end)
     worldTip:Show()
 
+    if delveTip:GetBottom() < 0 or worldTip:GetBottom() < 0 then
+        delveTip:ClearAllPoints()
+        delveTip:SetPoint("BOTTOMRIGHT", (charTip.frame or charTip), "TOP", -4, 0)
+        worldTip:ClearAllPoints()
+        worldTip:SetPoint("BOTTOMLEFT", (charTip.frame or charTip), "TOP", -4, 0)
+    end    
+
     PositionHoverOwner()
 
     -- Autohide wiring


### PR DESCRIPTION
Hello again,

I’m using an LDB container at the bottom of the screen, and I noticed that the Delves and Memories tooltips were spilling off the screen.
This PR adds a simple fix to position them above the character list if there isn’t enough space below.

Thanks again for the great addon! 🙂