### PR TITLE
Add more dynamic great vault reward tier colors

### DIFF
--- a/DataBroker.lua
+++ b/DataBroker.lua
@@ -602,6 +602,8 @@ DelveBuddy.Colors = {
     Green = "00ff00",
     Red   = "ff3333",
     Gray  = "aaaaaa",
+    Yellow = "ffff00",
+    Cyan = "00ffff",
 }
 
 function DelveBuddy:FormatKeysEarned(earned, max)
@@ -646,7 +648,15 @@ function DelveBuddy:FormatVaultCell(v)
     if v.progress >= v.threshold then
         local tier = v.level > 0 and v.level or "—"
         local iLvl = self.TierToVaultiLvl[v.level] or "?"
-        return self:ColorText(("Tier %s (%s)"):format(tier, iLvl), self.Colors.Green)
+        local color = self.Colors.Yellow -- tier 5-7
+        if type(tier) ~= "number" then
+            color = self.Colors.Gray     -- unknown tier
+        elseif tier <= 4 then
+            color = self.Colors.Cyan     -- tier 1-4
+        elseif tier >= 8 then
+            color = self.Colors.Green    -- tier 8+
+        end
+        return self:ColorText(("Tier %s (%s)"):format(tier, iLvl), color)
     else
         return self:ColorText(("%d/%d"):format(v.progress, v.threshold), self.Colors.Gray)
     end


### PR DESCRIPTION
### Summary

This PR introduces a dynamic color system for tier displays, making it easier to quickly identify the quality of Great Vault rewards based on delve tiers.

### Details

This change helps with a personal goal of tracking Great Vault progress. It implements a color-coded system that instantly shows the gear quality you can expect from a completed delve tier.

- **Cyan (1-4)**: Indicates **Veteran gear**.
- **Yellow (5-7)**: Indicates **Champion gear**.
- **Green (8+)**: Indicates **Hero gear**.
- **Gray**: Used as a fallback if the tier value is not a number.

This improves readability and gives players a quick visual reference for their progress.