### PR TITLE
Delve-O-Bot integration

### DIFF
--- a/DataBroker.lua
+++ b/DataBroker.lua
@@ -13,6 +13,9 @@ local ldbHovering = false
 -- Secure button for using Coffer Key Shards (created lazily, later)
 local cofferKeyShardButton
 
+-- Secure button for using the Delve-O-Bot 7001 toy (created lazily, later)
+local delveOBotButton
+
 -- Helper to dismiss all tooltips
 local function HideAllTips()
     tipMode = "none"
@@ -547,6 +550,98 @@ function DelveBuddy:PopulateDelveSection(tip)
         tip:SetLineScript(line, "OnLeave", function()
             GameTooltip:Hide()
         end)
+    end
+
+    -- Delve-O-Bot 7001
+    local toyID = 230850
+    if PlayerHasToy(toyID) then
+        -- Get toy name and icon
+        local _, toyName, toyFileID = C_ToyBox.GetToyInfo(toyID)
+        if not toyFileID or toyFileID == 0 then
+            _, toyName, toyFileID = C_ToyBox.GetToyInfo(toyID)
+        end
+        if toyFileID and toyFileID > 0 then
+            local toyIcon = self:TextureIcon(toyFileID)
+            toyName = ("%s %s"):format(toyIcon, toyName)
+        end
+
+        tip:AddSeparator()
+        local toyLine = tip:AddLine(toyName, "")
+
+        if not delveOBotButton and not InCombatLockdown() then
+            delveOBotButton = CreateFrame("Button", "DelveBuddySecureToyButton", UIParent, "SecureActionButtonTemplate")
+            delveOBotButton:SetAttribute("type", "toy")
+            delveOBotButton:SetAttribute("toy", toyID)
+            delveOBotButton:RegisterForClicks("AnyUp", "AnyDown")
+            delveOBotButton:SetMouseMotionEnabled(false)
+            delveOBotButton:SetToplevel(true)
+            delveOBotButton:SetSize(1, 1)
+        end
+
+        if delveOBotButton then
+            local row = tip.lines[toyLine]
+            if row then
+                delveOBotButton:ClearAllPoints()
+                delveOBotButton:SetParent(row:GetParent() or UIParent)
+                delveOBotButton:SetPoint("TOPLEFT", row, "TOPLEFT", 1, -1)
+                delveOBotButton:SetPoint("BOTTOMRIGHT", row, "BOTTOMRIGHT", -1, 1)
+                delveOBotButton:Show()
+            end
+        end
+
+        -- Update function to be called periodically
+        local function UpdateToyCooldownText()
+            local startTime, duration = C_Item.GetItemCooldown(toyID)
+            local currentTime = GetTime()
+            local timeLeft = (startTime + duration) - currentTime
+            local cdText
+            local toyText = toyName
+
+            if duration and duration > 0 and timeLeft and timeLeft > 0 then
+                local hours = math.floor(timeLeft / 3600)
+                local minutes = math.floor((timeLeft % 3600) / 60)
+                local seconds = math.floor(timeLeft % 60)
+                
+                -- Build the formatted string conditionally
+                local timeString = ""
+                if hours > 0 then
+                    timeString = timeString .. ("%dh "):format(hours)
+                end
+                if minutes > 0 or hours > 0 then
+                    timeString = timeString .. ("%dm "):format(minutes)
+                end
+                timeString = timeString .. ("%ds"):format(seconds)
+
+                cdText = ("ready in %s"):format(timeString)
+                cdText = self:ColorText(cdText, self.Colors.Red)
+                toyText = self:ColorText(toyText, self.Colors.Gray)
+            else
+                cdText = self:ColorText("click to summon", self.Colors.Green)
+            end
+            tip:SetCell(toyLine, 1, toyText)
+            tip:SetCell(toyLine, 2, cdText)
+        end
+
+        UpdateToyCooldownText()
+
+        -- Set up the OnUpdate timer
+        local lastUpdate = 0
+        tip:SetScript("OnUpdate", function(_, elapsed)
+            lastUpdate = lastUpdate + elapsed
+            if lastUpdate >= 1 then
+                UpdateToyCooldownText()
+                lastUpdate = 0
+            end
+        end)
+        
+        -- Clear the OnUpdate script when the tip is hidden
+        tip:SetScript("OnHide", function(self)
+            self:SetScript("OnUpdate", nil)
+            delveOBotButton:Hide()
+        end)
+
+        tip:SetLineScript(toyLine, "OnEnter", function() end)
+        tip:SetLineScript(toyLine, "OnLeave", function() end)
     end
 end
 


### PR DESCRIPTION
## Feature: Delve-O-Bot summon

### Summary of Changes
- If the player owns the **Delve-O-Bot 7001** toy, a new line is added to the **Bountiful Delves** section showing a real-time countdown timer.  
- When the toy is off cooldown, the line can be clicked to summon the **Delve-O-Bot 7001**.

### Screenshots
**Ready**  
<img width="233" height="128" alt="image" src="https://github.com/user-attachments/assets/f000e26b-706a-4bc9-88aa-6f17d944e2ab" />

**On Cooldown**  
<img width="232" height="127" alt="image" src="https://github.com/user-attachments/assets/56a86f26-f52d-4342-b48a-72e2cb474a66" />  
*Tooltip now displays a **live countdown** for the toy’s cooldown.*

### Notes
I wasn’t sure where to place the button, and the **Bountiful Delves** section felt like the most natural spot.  
Feel free to use any of the code provided — no need to include my rough snippets. 🙂

